### PR TITLE
쿠키 적용, 유저/관리자 로그인 로직 분리, 기능 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ build/
 ### for build and deploy ###
 /my.cnf
 /.env
-!**/Dockerfile
-!**/docker-compose.yml
+**/Dockerfile
+**/docker-compose.yml
 
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ build/
 ### for build and deploy ###
 /my.cnf
 /.env
-**/Dockerfile
-**/docker-compose.yml
+/Dockerfile
+/docker-compose.yml
 
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ build/
 ### for build and deploy ###
 /my.cnf
 /.env
-Dockerfile
-docker-compose.yml
+!**/Dockerfile
+!**/docker-compose.yml
 
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 ### for build and deploy ###
 /my.cnf
 /.env
+Dockerfile
+docker-compose.yml
 
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ build/
 ### for build and deploy ###
 /my.cnf
 /.env
-/Dockerfile
-/docker-compose.yml
+Dockerfile
+docker-compose.yml
 
 
 ### STS ###

--- a/src/main/java/comatchingfc/comatchingfc/admin/controller/AdminController.java
+++ b/src/main/java/comatchingfc/comatchingfc/admin/controller/AdminController.java
@@ -1,16 +1,12 @@
 package comatchingfc.comatchingfc.admin.controller;
 
-import comatchingfc.comatchingfc.admin.dto.AdminLoginReq;
 import comatchingfc.comatchingfc.admin.dto.AdminRegisterReq;
 import comatchingfc.comatchingfc.admin.service.AdminService;
-import comatchingfc.comatchingfc.auth.jwt.dto.TokenRes;
+import comatchingfc.comatchingfc.player.dto.PlayerInfoReq;
+import comatchingfc.comatchingfc.player.service.PlayerService;
 import comatchingfc.comatchingfc.utils.response.Response;
-import comatchingfc.comatchingfc.utils.security.SecurityUtil;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminService adminService;
-    private final SecurityUtil securityUtil;
+    private final PlayerService playerService;
 
     @PostMapping("/admin/register")
     public Response<Void> adminRegister(@RequestBody @Valid AdminRegisterReq registerReq) {
@@ -31,25 +27,16 @@ public class AdminController {
         return Response.ok(!adminService.isAccountDuplicated(accountId));
     }
 
-    @PostMapping("/admin/login")
-    public Response<Void> adminLogin(@RequestBody @Valid AdminLoginReq loginReq, HttpServletResponse response) {
-        TokenRes tokenRes = adminService.adminLogin(loginReq);
-
-        // Access Token을 HttpOnly 쿠키에 설정
-        ResponseCookie accessCookie = securityUtil.setAccessResponseCookie(tokenRes.getAccessToken());
-
-        // Refresh Token을 HttpOnly 쿠키에 설정
-        ResponseCookie refreshCookie = securityUtil.setRefreshResponseCookie(tokenRes.getRefreshToken());
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-
-        return Response.ok();
-    }
-
     @GetMapping("/auth/admin/activate/{ticket}")
     public Response<Void> activateUser(@PathVariable String ticket) {
         adminService.activateUser(ticket);
+        return Response.ok();
+    }
+
+    @PostMapping("/auth/admin/player")
+    public Response<Void> addPlayer(@RequestBody @Valid PlayerInfoReq playerInfoReq) {
+        playerService.addPlayer(playerInfoReq);
+
         return Response.ok();
     }
 }

--- a/src/main/java/comatchingfc/comatchingfc/auth/controller/AuthController.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/controller/AuthController.java
@@ -1,8 +1,6 @@
 package comatchingfc.comatchingfc.auth.controller;
 
-import comatchingfc.comatchingfc.auth.dto.Res.UserLoginRes;
 import comatchingfc.comatchingfc.auth.dto.req.UserLoginReq;
-import comatchingfc.comatchingfc.auth.jwt.JwtUtil;
 import comatchingfc.comatchingfc.auth.jwt.dto.TokenRes;
 import comatchingfc.comatchingfc.auth.service.AuthService;
 import comatchingfc.comatchingfc.utils.response.Response;
@@ -10,6 +8,8 @@ import comatchingfc.comatchingfc.utils.security.SecurityUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +21,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final SecurityUtil securityUtil;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/user/login")
     public Response<Void> userLogin(@RequestBody @Valid UserLoginReq userLoginReq, HttpServletResponse response) {
@@ -31,9 +30,11 @@ public class AuthController {
 //        TokenRes tokenRes = userLoginRes.getTokenRes();
         TokenRes tokenRes = authService.userLogin(userLoginReq);
 
-        // 쿠키에 토큰 저장
-        response.addHeader("Set-Cookie", securityUtil.setAccessResponseCookie(tokenRes.getAccessToken()).toString());
-        response.addHeader("Set-Cookie", securityUtil.setRefreshResponseCookie(tokenRes.getRefreshToken()).toString());
+        ResponseCookie accessCookie = securityUtil.setAccessResponseCookie(tokenRes.getAccessToken());
+        ResponseCookie refreshCookie = securityUtil.setRefreshResponseCookie(tokenRes.getRefreshToken());
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
 //        return Response.ok(userLoginRes);
         return Response.ok();

--- a/src/main/java/comatchingfc/comatchingfc/auth/filter/AdminAuthenticationFilter.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/filter/AdminAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package comatchingfc.comatchingfc.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import comatchingfc.comatchingfc.auth.jwt.JwtUtil;
+import comatchingfc.comatchingfc.auth.jwt.dto.admin.CustomAdmin;
+import comatchingfc.comatchingfc.auth.service.AdminUserDetailsService;
+import comatchingfc.comatchingfc.utils.security.SecurityUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class AdminAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final AdminUserDetailsService adminUserDetailsService;
+    private final JwtUtil jwtUtil;
+    private final SecurityUtil securityUtil;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            // JSON 형식으로 전송된 관리자 로그인 정보 파싱
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, String> creds = mapper.readValue(request.getInputStream(), Map.class);
+            String username = creds.get("accountId");
+            String password = creds.get("password");
+
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password);
+
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new AuthenticationServiceException("로그인 정보를 읽을 수 없습니다.", e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        // 인증 성공 시 JWT 토큰 생성 및 응답
+        CustomAdmin customAdmin = (CustomAdmin) authResult.getPrincipal();
+        String accessToken = jwtUtil.generateAccessToken(customAdmin.getUuid(), customAdmin.getRole());
+        String refreshToken = jwtUtil.generateRefreshToken(customAdmin.getUuid(), customAdmin.getRole());
+
+        ResponseCookie accessCookie = securityUtil.setAccessResponseCookie(accessToken);
+        ResponseCookie refreshCookie = securityUtil.setRefreshResponseCookie(refreshToken);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        // 응답을 종료하여 다음 필터로 전달되지 않도록 함
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        Map<String, String> successMap = new HashMap<>();
+        successMap.put("message", "로그인에 성공했습니다.");
+        new ObjectMapper().writeValue(response.getOutputStream(), successMap);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        // 인증 실패 시 처리 로직
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        Map<String, String> errorMap = new HashMap<>();
+        errorMap.put("error", "인증에 실패했습니다.");
+        new ObjectMapper().writeValue(response.getOutputStream(), errorMap);
+    }
+}

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/JwtFilter.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/JwtFilter.java
@@ -1,7 +1,9 @@
 package comatchingfc.comatchingfc.auth.jwt;
 
-import comatchingfc.comatchingfc.auth.jwt.dto.CustomUser;
-import comatchingfc.comatchingfc.auth.jwt.dto.UserDto;
+import comatchingfc.comatchingfc.auth.jwt.dto.admin.AdminDto;
+import comatchingfc.comatchingfc.auth.jwt.dto.admin.CustomAdmin;
+import comatchingfc.comatchingfc.auth.jwt.dto.user.CustomUser;
+import comatchingfc.comatchingfc.auth.jwt.dto.user.UserDto;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -15,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         try {
             if (accessToken != null && !jwtUtil.isExpired(accessToken)) {
-                log.info("엑세스 토큰 유효");
+//                log.info("엑세스 토큰 유효");
                 setAuthentication(accessToken);
                 filterChain.doFilter(request, response);
                 return;
@@ -75,13 +76,24 @@ public class JwtFilter extends OncePerRequestFilter {
         String uuid = jwtUtil.getUUID(accessToken);
         String role = jwtUtil.getRole(accessToken);
 
-        UserDto userDto = new UserDto();
-        userDto.setUuid(uuid);
-        userDto.setRole(role);
+        if (role.equals("ROLE_ADMIN")) {
+            AdminDto adminDto = AdminDto.builder()
+                    .uuid(uuid)
+                    .role(role)
+                    .build();
 
-        CustomUser customUser = new CustomUser(userDto);
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUser, null, customUser.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+            CustomAdmin adminUser = new CustomAdmin(adminDto);
+            Authentication authToken = new UsernamePasswordAuthenticationToken(adminUser, null, adminUser.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        } else {
+            UserDto userDto = new UserDto();
+            userDto.setUuid(uuid);
+            userDto.setRole(role);
+
+            CustomUser customUser = new CustomUser(userDto);
+            Authentication authToken = new UsernamePasswordAuthenticationToken(customUser, null, customUser.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
     }
 
     private String getTokenFromCookies(HttpServletRequest request, String cookieName) {

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/admin/AdminDto.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/admin/AdminDto.java
@@ -1,0 +1,17 @@
+package comatchingfc.comatchingfc.auth.jwt.dto.admin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminDto {
+    private String accountId;
+    private String password;
+    private String role;
+    private String uuid;
+}

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/admin/CustomAdmin.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/admin/CustomAdmin.java
@@ -1,0 +1,60 @@
+package comatchingfc.comatchingfc.auth.jwt.dto.admin;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomAdmin implements UserDetails {
+
+    private final AdminDto adminDto;
+
+    public CustomAdmin(AdminDto adminDto) {
+        this.adminDto = adminDto;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(adminDto.getRole()));
+    }
+
+    @Override
+    public String getPassword() {
+        return adminDto.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return adminDto.getAccountId();
+    }
+
+    public String getUuid() {
+        return adminDto.getUuid();
+    }
+
+    public String getRole() {
+        return adminDto.getRole();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/user/CustomUser.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/user/CustomUser.java
@@ -1,4 +1,4 @@
-package comatchingfc.comatchingfc.auth.jwt.dto;
+package comatchingfc.comatchingfc.auth.jwt.dto.user;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -30,7 +30,7 @@ public class CustomUser implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return "";
     }
 
     @Override

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/user/UserDto.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/dto/user/UserDto.java
@@ -1,4 +1,4 @@
-package comatchingfc.comatchingfc.auth.jwt.dto;
+package comatchingfc.comatchingfc.auth.jwt.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/comatchingfc/comatchingfc/auth/jwt/refresh/controller/RefreshTokenController.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/jwt/refresh/controller/RefreshTokenController.java
@@ -60,14 +60,8 @@ public class RefreshTokenController {
 
             refreshTokenRedisService.saveRefreshToken(uuid, newRefreshToken);
 
-            // Access Token을 HttpOnly 쿠키에 설정
-            ResponseCookie accessCookie = securityUtil.setAccessResponseCookie(newAccessToken);
-
-            // Refresh Token을 HttpOnly 쿠키에 설정
-            ResponseCookie refreshCookie = securityUtil.setRefreshResponseCookie(newRefreshToken);
-
-            response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-            response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+            response.addHeader("Set-Cookie", "accessToken=" + securityUtil.setAccessResponseCookie(newAccessToken).toString() + "; SameSite=None; Secure");
+            response.addHeader("Set-Cookie", "refreshToken=" + securityUtil.setRefreshResponseCookie(newRefreshToken).toString() + "; SameSite=None; Secure" );
 
             return Response.ok();
         } catch (Exception e) {

--- a/src/main/java/comatchingfc/comatchingfc/auth/service/AdminUserDetailsService.java
+++ b/src/main/java/comatchingfc/comatchingfc/auth/service/AdminUserDetailsService.java
@@ -1,0 +1,34 @@
+package comatchingfc.comatchingfc.auth.service;
+
+import comatchingfc.comatchingfc.admin.entity.Admin;
+import comatchingfc.comatchingfc.admin.repository.AdminRepository;
+import comatchingfc.comatchingfc.auth.jwt.dto.admin.AdminDto;
+import comatchingfc.comatchingfc.auth.jwt.dto.admin.CustomAdmin;
+import comatchingfc.comatchingfc.utils.uuid.UUIDUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserDetailsService implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String accountId) throws UsernameNotFoundException {
+        Admin admin = adminRepository.findByAccountId(accountId)
+                .orElseThrow(() -> new UsernameNotFoundException("관리자를 찾을 수 없습니다."));
+
+        AdminDto adminDto = AdminDto.builder()
+                .accountId(admin.getAccountId())
+                .password(admin.getPassword())
+                .role("ROLE_ADMIN")
+                .uuid(UUIDUtil.bytesToHex(admin.getUuid()))
+                .build();
+
+        return new CustomAdmin(adminDto);
+    }
+}

--- a/src/main/java/comatchingfc/comatchingfc/config/SecurityConfig.java
+++ b/src/main/java/comatchingfc/comatchingfc/config/SecurityConfig.java
@@ -1,11 +1,16 @@
 package comatchingfc.comatchingfc.config;
 
+import comatchingfc.comatchingfc.auth.filter.AdminAuthenticationFilter;
 import comatchingfc.comatchingfc.auth.jwt.JwtExceptionFilter;
 import comatchingfc.comatchingfc.auth.jwt.JwtFilter;
 import comatchingfc.comatchingfc.auth.jwt.JwtUtil;
+import comatchingfc.comatchingfc.auth.service.AdminUserDetailsService;
+import comatchingfc.comatchingfc.utils.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -29,10 +34,22 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final SecurityUtil securityUtil;
+    private final AdminUserDetailsService adminUserDetailsService;
 
-    private static final String[] CORS_WHITELIST = {
-            "http://localhost:5173"
-    };
+    private static final List<String> CORS_WHITELIST = List.of(
+            "https://fc.comatching.site"
+    );
+
+    private static final List<String> ADMIN_WHITELIST = List.of(
+            "/admin/register",
+            "/admin/login",
+            "/admin/check/**"
+    );
+
+    private static final List<String> USER_WHITELIST = List.of(
+            "/user/login"
+    );
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
@@ -41,7 +58,13 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        AuthenticationManager authenticationManager = authenticationConfiguration.getAuthenticationManager();
+
+        // 관리자 인증 필터 설정
+        AdminAuthenticationFilter adminAuthFilter = new AdminAuthenticationFilter(authenticationManager, adminUserDetailsService, jwtUtil, securityUtil);
+        adminAuthFilter.setFilterProcessesUrl("/admin/login"); // 관리자 로그인 URL 설정
+
         http
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()));
 
@@ -51,14 +74,17 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable);
 
         http
+                .addFilterBefore(adminAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(), JwtFilter.class);
 
 
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/test/match/**", "/auth/refresh", "/admin/register", "/admin/login", "/admin/check/**", "/user/login", "/api/participations").permitAll()
+                        .requestMatchers("/test/match/**", "/auth/refresh",  "/api/participations").permitAll()
+                        .requestMatchers(ADMIN_WHITELIST.toArray(new String[0])).permitAll()
                         .requestMatchers("/auth/admin/**").hasRole("ADMIN")
+                        .requestMatchers(USER_WHITELIST.toArray(new String[0])).permitAll()
                         .requestMatchers("/auth/pending/**").hasRole("PENDING")
                         .requestMatchers("/auth/user/**").hasRole("USER")
                         .requestMatchers("/check-role").hasAnyRole("ADMIN", "PENDING", "USER")
@@ -74,7 +100,7 @@ public class SecurityConfig {
 
     private CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
+        configuration.setAllowedOrigins(CORS_WHITELIST);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(Collections.singletonList("*"));
@@ -89,5 +115,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/comatchingfc/comatchingfc/player/dto/PlayerInfoReq.java
+++ b/src/main/java/comatchingfc/comatchingfc/player/dto/PlayerInfoReq.java
@@ -1,0 +1,23 @@
+package comatchingfc.comatchingfc.player.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PlayerInfoReq {
+
+    @NotNull
+    @NotEmpty
+    private String name;
+
+    private int backNumber;
+
+    @NotNull
+    @NotEmpty
+    private String position;
+
+    @NotNull
+    @NotEmpty
+    private String cheerPropensity;
+}

--- a/src/main/java/comatchingfc/comatchingfc/player/service/PlayerService.java
+++ b/src/main/java/comatchingfc/comatchingfc/player/service/PlayerService.java
@@ -1,10 +1,13 @@
 package comatchingfc.comatchingfc.player.service;
 
+import comatchingfc.comatchingfc.player.dto.PlayerInfoReq;
 import comatchingfc.comatchingfc.player.dto.PlayerRes;
+import comatchingfc.comatchingfc.player.entity.Player;
 import comatchingfc.comatchingfc.player.repository.PlayerRepository;
 import comatchingfc.comatchingfc.user.enums.CheerPropensityEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,5 +25,17 @@ public class PlayerService {
                         .backNumber(player.getBackNumber())
                         .position(player.getPosition())
                         .build()).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void addPlayer(PlayerInfoReq playerInfoReq) {
+        Player player = Player.builder()
+                .name(playerInfoReq.getName())
+                .backNumber(playerInfoReq.getBackNumber())
+                .position(playerInfoReq.getPosition())
+                .cheerPropensityEnum(CheerPropensityEnum.from(playerInfoReq.getCheerPropensity()))
+                .build();
+
+        playerRepository.save(player);
     }
 }

--- a/src/main/java/comatchingfc/comatchingfc/user/controller/UserController.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/controller/UserController.java
@@ -1,10 +1,7 @@
 package comatchingfc.comatchingfc.user.controller;
 
 import comatchingfc.comatchingfc.auth.jwt.dto.TokenRes;
-import comatchingfc.comatchingfc.player.dto.PlayerRes;
-import comatchingfc.comatchingfc.user.dto.SavePropensityRes;
-import comatchingfc.comatchingfc.user.dto.SurveyResult;
-import comatchingfc.comatchingfc.user.dto.FeatureReq;
+import comatchingfc.comatchingfc.user.dto.*;
 import comatchingfc.comatchingfc.user.service.CheerPropensityService;
 import comatchingfc.comatchingfc.user.service.UserService;
 import comatchingfc.comatchingfc.utils.response.Response;
@@ -14,7 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,25 +41,41 @@ public class UserController {
      * @param response Role이 바뀐 토큰 제공
      */
     @PostMapping("/auth/pending/survey")
-    public Response<List<PlayerRes>> saveCheerPropensity(@RequestBody SurveyResult surveyResult, HttpServletResponse response) {
+    public Response<PropensityRes> saveCheerPropensity(@RequestBody SurveyResult surveyResult, HttpServletResponse response) {
         SavePropensityRes savePropensityRes = cheerPropensityService.saveCheerPropensity(surveyResult);
 
         TokenRes tokenRes = savePropensityRes.getTokenRes();
         response.addHeader("Set-Cookie", securityUtil.setAccessResponseCookie(tokenRes.getAccessToken()).toString());
         response.addHeader("Set-Cookie", securityUtil.setRefreshResponseCookie(tokenRes.getRefreshToken()).toString());
 
-        return Response.ok(savePropensityRes.getPlayers());
+        return Response.ok(savePropensityRes.getPropensityRes());
     }
 
     /**
      * 유저 정보 수정
      * @param featureReq 수정된 유저 정보
      */
-
     @PatchMapping("/auth/user/feature")
     public Response<Void> updateUserFeature(@RequestBody @Valid FeatureReq featureReq) {
         userService.updateFeature(featureReq);
         return Response.ok();
+    }
+
+    /**
+     * 메인페이지 Get 메소드
+     * @return 내 정보, 매칭 상대 정보 (매칭 하지 않았으면 null)
+     */
+    // todo: 매칭 여부 판별 + 매칭 된 상대 정보 넣는 로직 추가 필요
+    @GetMapping("/auth/user/info")
+    public Response<UserInfoRes> getUserInfo() {
+        UserInfo myInfo = userService.getUserInfo();
+        //todo : 매칭 했는지 판별 + 매칭된 상대 정보 UserInfo dto에 담기
+        // 아래는 매칭은 안한 사람인 경우 상대 정보 null
+        UserInfoRes userInfoRes = UserInfoRes.builder()
+                .myInfo(myInfo)
+                .enemyInfo(null)
+                .build();
+        return Response.ok(userInfoRes);
     }
 
     /**

--- a/src/main/java/comatchingfc/comatchingfc/user/dto/PropensityRes.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/dto/PropensityRes.java
@@ -1,0 +1,18 @@
+package comatchingfc.comatchingfc.user.dto;
+
+import comatchingfc.comatchingfc.player.dto.PlayerRes;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PropensityRes {
+
+    private String cheerPropensity;
+
+    private List<PlayerRes> players;
+}

--- a/src/main/java/comatchingfc/comatchingfc/user/dto/SavePropensityRes.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/dto/SavePropensityRes.java
@@ -2,19 +2,16 @@ package comatchingfc.comatchingfc.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import comatchingfc.comatchingfc.auth.jwt.dto.TokenRes;
-import comatchingfc.comatchingfc.player.dto.PlayerRes;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
+@Builder
 @AllArgsConstructor
 public class SavePropensityRes {
 
-    private String cheerPropensity;
-
-    private List<PlayerRes> players;
+    private PropensityRes propensityRes;
 
     @JsonIgnore
     private TokenRes tokenRes;

--- a/src/main/java/comatchingfc/comatchingfc/user/dto/UserInfo.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/dto/UserInfo.java
@@ -1,0 +1,19 @@
+package comatchingfc.comatchingfc.user.dto;
+
+import comatchingfc.comatchingfc.user.enums.CheerPropensityEnum;
+import comatchingfc.comatchingfc.user.enums.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfo {
+    private String username;
+    private String socialId;
+    private String cheeringPlayer;
+    private int age;
+    private Gender gender;
+    private CheerPropensityEnum cheerPropensity;
+}

--- a/src/main/java/comatchingfc/comatchingfc/user/dto/UserInfoRes.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/dto/UserInfoRes.java
@@ -1,0 +1,13 @@
+package comatchingfc.comatchingfc.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoRes {
+    private UserInfo myInfo;
+    private UserInfo enemyInfo;
+}

--- a/src/main/java/comatchingfc/comatchingfc/user/service/CheerPropensityService.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/service/CheerPropensityService.java
@@ -4,6 +4,7 @@ import comatchingfc.comatchingfc.auth.TokenUtil;
 import comatchingfc.comatchingfc.auth.jwt.dto.TokenRes;
 import comatchingfc.comatchingfc.player.dto.PlayerRes;
 import comatchingfc.comatchingfc.player.service.PlayerService;
+import comatchingfc.comatchingfc.user.dto.PropensityRes;
 import comatchingfc.comatchingfc.user.dto.SavePropensityRes;
 import comatchingfc.comatchingfc.user.dto.SurveyResult;
 import comatchingfc.comatchingfc.user.entity.CheerPropensity;
@@ -75,7 +76,12 @@ public class CheerPropensityService {
         TokenRes tokenRes = tokenUtil.makeTokenRes(userUuid, userRole);
         List<PlayerRes> samePropensityPlayers = playerService.getSamePropensityPlayers(type);
 
-        return new SavePropensityRes(type.getValue(), samePropensityPlayers, tokenRes);
+        PropensityRes propensityRes = PropensityRes.builder()
+                .cheerPropensity(type.getValue())
+                .players(samePropensityPlayers)
+                .build();
+
+        return new SavePropensityRes(propensityRes, tokenRes);
     }
 
     private CheerPropensity buildCheerPropensities(CheerPropensityEnum cheerPropensityEnum, int score) {

--- a/src/main/java/comatchingfc/comatchingfc/user/service/UserService.java
+++ b/src/main/java/comatchingfc/comatchingfc/user/service/UserService.java
@@ -2,6 +2,8 @@ package comatchingfc.comatchingfc.user.service;
 
 import comatchingfc.comatchingfc.auth.jwt.refresh.service.RefreshTokenRedisService;
 import comatchingfc.comatchingfc.user.dto.FeatureReq;
+import comatchingfc.comatchingfc.user.dto.UserInfo;
+import comatchingfc.comatchingfc.user.entity.UserFeature;
 import comatchingfc.comatchingfc.user.entity.Users;
 import comatchingfc.comatchingfc.user.enums.Gender;
 import comatchingfc.comatchingfc.user.repository.UserRepository;
@@ -34,6 +36,20 @@ public class UserService {
         user.getUserAiInfo().getUserFeature().updateGender(gender);
         user.updateSocialId(featureReq.getSocialId());
         user.updateCheeringPlayer(featureReq.getCheeringPlayer());
+    }
+
+    public UserInfo getUserInfo() {
+        Users user = securityUtil.getCurrentUserEntity();
+        UserFeature userFeature = user.getUserAiInfo().getUserFeature();
+
+        return UserInfo.builder()
+                .username(user.getUsername())
+                .age(userFeature.getAge())
+                .gender(userFeature.getGender())
+                .socialId(user.getSocialId())
+                .cheeringPlayer(user.getCheeringPlayer())
+                .cheerPropensity(userFeature.getCheerPropensityEnum())
+                .build();
     }
 
     /**


### PR DESCRIPTION
- 쿠키 사용한 토큰 인증 적용
- 유저/관리자 로그인 로직 분리
- 설문 결과로 같은 유형의 선수등의 정보도 응답에 포함
- 메인페이지 내 정보 불러오기 기능 추가
    - 내 정보 불러오기는 매칭 후 상대 정보도 응답에 포함시켜야 함